### PR TITLE
Fix three cold-start defects (0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.2.1 — 2026-08-31
+
+Three cold-start defects, all of them things a first-time user would hit and none of
+them things an existing user would report:
+
+- **A missing browser now tells you what to run.** npm installs Playwright's driver but
+  not the browsers it drives, so the first `npx uisight` on a clean machine died on a raw
+  Playwright stack trace. It now says `npx playwright install chromium` and explains why.
+  The README says it too, as step one.
+- **No locale is forced any more.** `locale: 'tr-TR'` was hard-coded in both the CLI and
+  the panel, so every user in the world audited their app in Turkish — language switchers,
+  date formats and all. The page now renders the way your machine would render it, and
+  `--locale en-US` (or `UISIGHT_LOCALE`) pins one when you want a fixed baseline.
+- **Report timestamps are locale-neutral** (ISO + UTC) instead of Turkish-formatted.
+
+Two leftover Turkish strings in CLI output are gone, and the missing-browser path is
+covered by a test.
+
 ## 0.2.0 — 2026-08-30
 
 **Breaking.** The internals were written in Turkish (this started as a personal tool). Everything

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Scope note: uisight is for **web and responsive UIs**. For native iOS/Android ap
 ## Quickstart
 
 ```bash
+# once per machine: Playwright ships over npm but downloads browsers separately
+npx playwright install chromium webkit   # ~300 MB; chromium alone is enough to start
+
 # one-shot audit: PNGs + gallery + report for iPhone/Pixel/desktop, light+dark
 npx uisight https://yourapp.com --theme both
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uisight",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "mcpName": "io.github.yusufcemres/uisight",
   "description": "Your AI can already see the screen — it just can't measure it. uisight is an MCP server for web/responsive UIs: live mobile+desktop sessions, a measurement engine (contrast, touch targets, theme drift) that reports findings as text, and a panel you and your agent share.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/sololabstr/uisight",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "uisight",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/cli.mjs
+++ b/src/cli.mjs
@@ -49,11 +49,12 @@ const DEFAULT_DEVICES = ['iphone-15', 'pixel'];
 
 // --- Arguments --------------------------------------------------------------
 function parseArgs(argv) {
-  const o = { url: null, device: DEFAULT_DEVICES, path: ['/'], theme: ['light'], full: false, live: null, settle: 1200, watch: 0, open: true };
+  const o = { url: null, device: DEFAULT_DEVICES, path: ['/'], theme: ['light'], full: false, live: null, settle: 1200, watch: 0, open: true, locale: null };
   const rest = [];
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--device' || a === '-d') o.device = argv[++i].split(',').map((s) => s.trim());
+    else if (a === '--locale') o.locale = argv[++i];
     else if (a === '--path' || a === '-p') o.path = argv[++i].split(',').map((s) => s.trim());
     else if (a === '--theme' || a === '-t') o.theme = argv[++i] === 'both' ? ['light', 'dark'] : [argv[i]];
     else if (a === '--full') o.full = true;
@@ -81,6 +82,7 @@ Options
   --full         full-page screenshots (not just the viewport)
   --wait <ms>    settle time after page load                            (default: 1200)
   --watch <s>    continuous mode: re-captures every <s> seconds, gallery auto-refreshes
+  --locale <tag> pin a browser locale, e.g. en-US (default: this machine's)
   --no-open      do not auto-open the gallery in the browser
   --live <device>  opens a real window you can browse by hand (no automation)
 
@@ -96,6 +98,23 @@ MCP server for Claude Code / Cursor / Antigravity:  uisight-mcp
 
 // --- Helpers ----------------------------------------------------------------
 const slug = (s) => (s.replace(/^\//, '').replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '') || 'home');
+
+/**
+ * npm installs the Playwright package but not the browsers it drives, so the very
+ * first `npx uisight` on a clean machine used to die on a raw Playwright stack
+ * trace. That is the worst possible first impression: it reads like the tool is
+ * broken, and there is nothing in it telling you what to run.
+ */
+export function missingBrowser(e, engine) {
+  const s = String(e);
+  if (!/Executable doesn't exist|playwright install|browserType\.launch/i.test(s)) return e;
+  return new Error(
+    `${engine} is not installed yet.\n\n` +
+    `  npx playwright install ${engine}\n\n` +
+    `Playwright ships the driver over npm but downloads browsers separately (~150 MB, once).\n` +
+    `For real iOS Safari on iPhone profiles, add webkit: npx playwright install chromium webkit`
+  );
+}
 
 export function deviceSettings(pwName) {
   const d = devices[pwName];
@@ -306,7 +325,7 @@ export const INSPECTION_SCRIPT = (settings) => {
   result.lowContrast = result.lowContrast.slice(0, 12);
   result.buttonIssues = result.buttonIssues.slice(0, 12);
 
-  // 1) Yatay tasma — mobilde en sik bug.
+  // 1) Horizontal overflow — the most common mobile bug there is.
   const docWidth = document.documentElement.scrollWidth;
   const visibleWidth = window.innerWidth;
   if (docWidth > visibleWidth + 2) {
@@ -359,7 +378,7 @@ export const INSPECTION_SCRIPT = (settings) => {
   return result;
 };
 
-// --- Canli mod --------------------------------------------------------------
+// --- Live mode ---------------------------------------------------------------
 async function canliAc(url, cihazAnahtar) {
   const p = PROFILES[cihazAnahtar];
   if (!p) throw new Error(`Bilinmeyen device: ${cihazAnahtar}`);
@@ -374,7 +393,7 @@ async function canliAc(url, cihazAnahtar) {
   await browser.close();
 }
 
-// --- Ana akis ---------------------------------------------------------------
+// --- Main flow ---------------------------------------------------------------
 async function main() {
   const o = parseArgs(process.argv.slice(2));
   if (o.printHelp || !o.url) { printHelp(); process.exit(o.url ? 0 : 1); }
@@ -405,7 +424,7 @@ async function tur(o) {
 
   for (const key of o.device) {
     const p = PROFILES[key];
-    if (!p) { console.log(`  ! bilinmeyen device atlandi: ${key}`); continue; }
+    if (!p) { console.log(`  ! unknown device skipped: ${key} (known: ${Object.keys(PROFILES).join(', ')})`); continue; }
 
     // If WebKit will not launch on this machine (the missing-DLL case on Windows), fall back to Chromium;
     // layout/color checks keep running; the report states the engine plainly.
@@ -414,17 +433,22 @@ async function tur(o) {
       try {
         engineCache[engineUsed] = await (engineUsed === 'webkit' ? webkit : chromium).launch();
       } catch (e) {
-        if (engineUsed !== 'webkit') throw e;
-        console.log(`  ! webkit acilmadi (${String(e).split('\n')[0].slice(0, 60)}) -> chromium'a dusuluyor`);
+        if (engineUsed !== 'webkit') throw missingBrowser(e, 'chromium');
+        console.log(`  ! webkit would not launch (${String(e).split('\n')[0].slice(0, 60)}) -> falling back to chromium`);
         engineUsed = 'chromium-fallback';
-        if (!engineCache[engineUsed]) engineCache[engineUsed] = await chromium.launch();
+        try {
+          if (!engineCache[engineUsed]) engineCache[engineUsed] = await chromium.launch();
+        } catch (e2) { throw missingBrowser(e2, 'chromium'); }
       }
     }
     const browser = engineCache[engineUsed];
     const engineName = engineUsed === 'chromium-fallback' ? 'chromium (no webkit — iOS-specific bugs WILL be missed)' : engineUsed;
 
     for (const theme of o.theme) {
-      const ctx = await browser.newContext({ ...deviceSettings(p.pw), colorScheme: theme, locale: 'tr-TR' });
+      // No locale is forced: the page renders the way this machine would render it.
+      // A hard-coded locale used to ship here, so every user in the world audited
+      // their app in Turkish — language switchers and date formats included.
+      const ctx = await browser.newContext({ ...deviceSettings(p.pw), colorScheme: theme, ...(o.locale ? { locale: o.locale } : {}) });
       const page = await ctx.newPage();
 
       for (const path of o.path) {
@@ -470,7 +494,7 @@ async function tur(o) {
   const lines = [];
   lines.push(`# uisight report — ${o.url}`);
   lines.push('');
-  lines.push(`- Date: ${new Date().toLocaleString('tr-TR')}`);
+  lines.push(`- Date: ${new Date().toISOString().replace('T', ' ').slice(0, 19)} UTC`);
   lines.push(`- Devices: ${o.device.join(', ')} | Themes: ${o.theme.join(', ')} | Paths: ${o.path.join(', ')}`);
   lines.push(`- Output: ${outDir}`);
   lines.push('');
@@ -658,7 +682,7 @@ ${o.watch ? `<meta http-equiv="refresh" content="${o.watch}">` : ''}
 <div class="ust">
   <h1>uisight</h1>
   <a href="${esc(o.url)}" target="_blank">${esc(o.url)}</a>
-  <span class="info">${new Date().toLocaleString('en-US')} · ${records.length} previews</span>
+  <span class="info">${new Date().toISOString().replace('T', ' ').slice(0, 16)} UTC · ${records.length} previews</span>
   ${o.watch ? `<span class="live">LIVE — refreshes every ${o.watch}s</span>` : ''}
   <span class="info">Spot a problem? Tell your AI the <b>card number</b> (e.g. "the header collides on card 3").</span>
 </div>

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -3,19 +3,18 @@
  * uisight — LIVE PANEL (multi-session, synchronised).
  *
  * Web + mobile side by side at the same time: each session gets its own Playwright
- * context and streams live over CDP screencast. You click and type in the panel ->
- * ilgili oturuma gider. Adres cubugu TUM oturumlara gider (URL-senkron).
- * AI ayni oturumlari MCP uzerinden gorur/olcer/eller (mcp.mjs).
+ * context and streams live over CDP screencast. You click and type in the panel and
+ * it lands in that session. The address bar drives EVERY session at once. The AI sees,
+ * measures and drives those same sessions over MCP (mcp.mjs).
  *
- * Kullanim:
- *   node server.mjs http://localhost:3000                  # web(masaustu) + mobile(pixel)
- *   node server.mjs <url> --device iphone-se --web laptop   # profillleri sel
+ * Usage:
+ *   node server.mjs http://localhost:3000                  # web (desktop) + mobile (pixel)
+ *   node server.mjs <url> --device iphone-se --web laptop  # pick the profiles
  *   node server.mjs <url> --single                         # mobile session only
  *   UISIGHT_FALLBACK=1 node server.mjs <url>               # fallback stream instead of screencast (testing)
  *
  * Human -> AI channel: the panel's "Mark" button queues a note + the current frame
- * under live/marks/;
- * AI bunlari MCP `marks` araciyla okur.
+ * under live/marks/, and the AI reads them with the MCP `marks` tool.
  */
 
 import { createServer } from 'node:http';
@@ -26,7 +25,7 @@ import { fileURLToPath } from 'node:url';
 import { exec } from 'node:child_process';
 import { homedir, platform } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { PROFILES, deviceSettings, INSPECTION_SCRIPT } from './cli.mjs';
+import { PROFILES, deviceSettings, INSPECTION_SCRIPT, missingBrowser } from './cli.mjs';
 
 
 // Live artifacts live under the user's home — never inside the package (npx → node_modules).
@@ -35,10 +34,10 @@ const MARKS_DIR = join(LIVE_DIR, 'marks');
 const READ_DIR = join(MARKS_DIR, 'read');
 for (const d of [LIVE_DIR, MARKS_DIR, READ_DIR]) mkdirSync(d, { recursive: true });
 
-// --- Argumanlar ---
+// --- Arguments ---
 const argv = process.argv.slice(2);
 const arg = (ad, vars) => { const i = argv.indexOf(ad); return i >= 0 && argv[i + 1] ? argv[i + 1] : vars; };
-const FLAGS_WITH_VALUE = new Set(['--device', '--desktop', '--theme', '--port']);
+const FLAGS_WITH_VALUE = new Set(['--device', '--desktop', '--theme', '--port', '--locale']);
 let targetUrl = null;
 for (let i = 0; i < argv.length; i++) {
   const a = argv[i];
@@ -53,13 +52,14 @@ const PORT = Number(process.env.UISIGHT_PORT || process.env.MOBILQA_PORT || arg(
 const NO_OPEN = argv.includes('--no-open');
 const SINGLE = argv.includes('--single');
 const FORCE_FALLBACK = (process.env.UISIGHT_FALLBACK || process.env.MOBILQA_YEDEK) === '1';
+const LOCALE = process.env.UISIGHT_LOCALE || arg('--locale', null);
 
 // --- Security: this tool is a local server that DRIVES a browser session. Two layers:
 //   (1) bind to loopback only (cuts off LAN access) — see listen() below.
 //   (2) Host allowlist (DNS-rebinding guard, ALL endpoints) + an action token (CSRF guard, mutating endpoints).
 // The panel sends the token in a header when it fetches its own origin; a malicious
-// tab (POSTing to localhost from the same machine) cannot know it, and the text/plain form trick
-// custom header EKLEYEMEZ → reddedilir.
+// tab (POSTing to localhost from the same machine) cannot know it, and the text/plain
+// form trick cannot add a custom header, so it is refused.
 const TOKEN = randomUUID();
 // Write the token to a per-port local file: the MCP server (a separate process on the
 // same machine) reads it and sends it in a header. A cross-site page CANNOT read this file.
@@ -82,7 +82,7 @@ function hostAllowed(req) {
     && (port === '' || port === String(PORT));
 }
 
-// --- Genel state ---
+// --- Shared state ---
 const state = {
   url: targetUrl,
   theme: arg('--theme', 'light'),
@@ -95,7 +95,7 @@ const sessions = new Map();
 let browser = null;
 const clients = new Set(); // SSE
 
-// --- Yardimcilar ---
+// --- Helpers ---
 function broadcast(event, data) {
   const packet = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
   for (const r of clients) { try { r.write(packet); } catch { clients.delete(r); } }
@@ -133,17 +133,21 @@ async function openSession(id, deviceKey, theme) {
 
   const profile = PROFILES[deviceKey] || PROFILES[id === 'web' ? 'desktop' : 'pixel'];
   const settings = deviceSettings(profile.pw);
-  if (!browser) browser = await chromium.launch();
+  if (!browser) {
+    try { browser = await chromium.launch(); }
+    catch (e) { throw missingBrowser(e, 'chromium'); }
+  }
 
-  const ctx = await browser.newContext({ ...settings, colorScheme: theme, locale: 'tr-TR' });
+  // No locale is forced — see the same note in cli.mjs. --locale pins one.
+  const ctx = await browser.newContext({ ...settings, colorScheme: theme, ...(LOCALE ? { locale: LOCALE } : {}) });
   const page = await ctx.newPage();
   const o = {
     id, deviceKey, profile, ctx, page, cdp: null, fallbackTimer: null,
     viewport: settings.viewport, lastFrame: null, lastWrite: 0,
   };
-  // Register in the map only AFTER the first goto completes: otherwise the setup goto and an
-  // gelen `git` eylemi ayni sayfada yarisirsa Chromium gec kalan navigasyonu
-  // chrome-error olarak commit edebiliyor (17 Agu MCP live testinde yasandi).
+  // Register in the map only AFTER the first goto completes: when the setup goto races
+  // an incoming `goto` action on the same page, Chromium can commit the late navigation
+  // as chrome-error (hit during the Aug 17 MCP live test).
 
   page.on('pageerror', (e) => addRecord(id, 'js-error', e));
   page.on('console', (m) => { if (m.type() === 'error') addRecord(id, 'console', m.text()); });
@@ -160,7 +164,7 @@ async function openSession(id, deviceKey, theme) {
     addRecord(id, 'page', state.error);
   }
 
-  sessions.set(id, o); // page oturdu — artik eylemlere acik
+  sessions.set(id, o); // the page has settled — actions may reach it now
   await startStream(o);
   broadcast('state', publicState());
   return o;
@@ -284,7 +288,7 @@ async function applyAction(g) {
       const targets = g.session ? [sessions.get(g.session)].filter(Boolean) : [...sessions.values()];
       for (const o of targets) {
         try {
-          // Timeout: target sayfada engelleyici bir native dialog varsa evaluate suresiz asili kalirdi.
+          // Timeout: a blocking native dialog on the target page would otherwise leave evaluate hanging forever.
           o.page.setDefaultTimeout(20000);
           const d = await o.page.evaluate(INSPECTION_SCRIPT, { mobile: o.profile.mobile !== false });
           results.push({ session: o.id, device: o.deviceKey, label: o.profile.label, theme: state.theme, url: state.url, inspection: d });
@@ -596,7 +600,7 @@ const PANEL_HTML_SABLON = `<!doctype html><html lang="en"><head><meta charset="u
       if (d.tinyText?.length) p.push(rz('#33383e','under 12px ' + d.tinyText.length));
       if (!p.length) p.push(rz('#264d2c','clean'));
       const li = [];
-      // Bulgu metinleri DENETLENEN sayfanin DOM'undan gelir → escape ZORUNLU,
+      // Finding text comes from the INSPECTED page's DOM, so escaping is mandatory:
       // otherwise that page could run script on the panel's origin (stored XSS).
       for (const x of (d.invisibleText||[])) li.push('<li class="k">INVISIBLE ' + esc(x.ratio) + ':1 — "' + esc(x.text) + '"</li>');
       for (const x of (d.buttonIssues||[]).slice(0,5)) li.push('<li class="u">BUTTON "' + esc(x.text) + '" → ' + esc(x.issues.join(' · ')) + '</li>');
@@ -631,8 +635,8 @@ server.listen(PORT, '127.0.0.1', () => {
 
 // Browser sessions are separate: even if this throws, the server stays up and the panel shows the error.
 try {
-  // Parallel setup: waiting in sequence made the total the SUM of both sessions, and
-  // MCP'nin 30sn hazir-olma butcesini asabiliyordu.
+  // Parallel setup: waiting in sequence made the total the SUM of both sessions, which
+  // could blow past the MCP client's 30s readiness budget.
   await Promise.all([
     SINGLE ? null : openSession('web', arg('--desktop', 'desktop'), state.theme),
     openSession('mobile', arg('--device', 'pixel'), state.theme),

--- a/test/mcp-tools.test.mjs
+++ b/test/mcp-tools.test.mjs
@@ -89,3 +89,27 @@ test('every tool describes itself and its arguments', async () => {
     }
   }
 });
+
+/**
+ * Cold-start guidance.
+ *
+ * npm installs Playwright's driver but not the browsers it drives, so the very first
+ * `npx uisight` on a clean machine hit a raw Playwright stack trace. 99 people cloned
+ * this repo and filed zero issues — a first run that looks broken is the likeliest
+ * reason someone leaves without saying anything.
+ */
+test('a missing browser is explained, and other errors pass through untouched', async () => {
+  const { missingBrowser } = await import('../src/cli.mjs');
+
+  const playwrightSays = new Error(
+    "browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1200/chrome\n" +
+    'Please run the following command to download new browsers:\n    npx playwright install'
+  );
+  const explained = missingBrowser(playwrightSays, 'chromium');
+  assert.notEqual(explained, playwrightSays, 'the raw Playwright error must not reach the user');
+  assert.match(explained.message, /npx playwright install chromium/, 'it must name the exact command to run');
+
+  // Swallowing unrelated failures would be worse than the original problem.
+  const unrelated = new Error('net::ERR_CONNECTION_REFUSED at http://localhost:3000');
+  assert.equal(missingBrowser(unrelated, 'chromium'), unrelated, 'unrelated errors must pass through unchanged');
+});


### PR DESCRIPTION
99 unique clones, 0 issues. That is a symptom, not a quiet success — so I looked at what a first run actually does on a clean machine.

**1. A missing browser died on a raw Playwright stack trace.** npm installs Playwright's driver but not the browsers it drives, so the very first `npx uisight` looked like the tool was broken, with nothing in the output telling you what to run. It now names the command, and the README says it as step one — which it never did.

**2. `locale: 'tr-TR'` was hard-coded** in both the CLI and the panel. Every user in the world was auditing their app in Turkish: language switchers, date formats, everything. For a tool whose whole job is showing you what your UI actually looks like, that is a correctness bug. No locale is forced now; `--locale en-US` (or `UISIGHT_LOCALE`) pins one when you want a fixed baseline.

**3. Report timestamps were Turkish-formatted.** Now ISO + UTC.

Also: two Turkish strings still reaching CLI output, plus the comment continuation lines the 0.2.0 sweep matched only the first line of.

## Verified

- 18/18 tests. The missing-browser path is covered, including the case that matters more than the happy one: it must **not** swallow unrelated errors, so a real `ERR_CONNECTION_REFUSED` still reaches you unchanged.
- `nfc.sololabs.tr` re-audited against the pre-migration baseline: 44px 1/1/0, 12px 4, no-alt 2 — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)